### PR TITLE
Fixing discord cannot be in username issue

### DIFF
--- a/discord-build-success-webhook.js
+++ b/discord-build-success-webhook.js
@@ -1,5 +1,5 @@
 module.exports = {
-  username: "Discord Action Bot",
+  username: "Github Action Bot",
   avatar_url: "https://i.imgur.com/Hrbi1Ht.jpg",
   embeds: [
     {


### PR DESCRIPTION
# Pull Request Requirements
1. Issue: Discord added a check for the webhook payload to not include discord in the username property.
```
statusCode: 400
{"username": ["Username cannot contain \"discord\""]}
````
3. Updating username to `Github Action Bot`
4. @Poss111 
